### PR TITLE
Adding hardware variants for both battery and wired Nest Smoke Detectors

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2809,7 +2809,16 @@
         {
             "manufacturer": "Google",
             "model": "Topaz-2.7",
-            "battery_type": "MANUAL"
+            "hw_version": "Battery",
+            "battery_type": "AA",
+            "battery_quantity": 6
+        },
+        {
+            "manufacturer": "Google",
+            "model": "Topaz-2.7",
+            "hw_version": "Wired",
+            "battery_type": "AA",
+            "battery_quantity": 3
         },
         {
             "manufacturer": "Google",


### PR DESCRIPTION
This is related to #153.  I'm assuming at the time that issue was closed (late 2023) and the 2.7 model was set to MANUAL, it was either because a) Battery Notes didn't support hw_version yet, or b) the Nest Protect integration didn't return the Wired/Battery values.  Regardless, I have both hardware models, and it does appear to differentiate now, so I've edited/removed the previous Topaz-2.7 and made 2x entries for the wired and battery versions separately.